### PR TITLE
Change R devtools installation instructions to specify the r-package subdirectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ install.packages("drf")
 The development version can be installed from github
 
 ```R
-library(devtools)
-install_github("lorismichel/drf")
+devtools::install_github("lorismichel/drf",subdir = "r-package/drf")
 ```
 
 Another installation possibility is to clone the repo, and then within the r-package folder run


### PR DESCRIPTION
A tiny change to make it easier for people trying to install the R package using devtools.